### PR TITLE
fix: app gets under status bar without the need of opening keyboard

### DIFF
--- a/src/android/com/mesmotronic/plugins/FullScreenPlugin.java
+++ b/src/android/com/mesmotronic/plugins/FullScreenPlugin.java
@@ -360,8 +360,7 @@ public class FullScreenPlugin extends CordovaPlugin
 			{
 				try
 				{
-			        window.clearFlags(WindowManager.LayoutParams.FLAG_TRANSLUCENT_STATUS);
-					
+					decorView.setSystemUiVisibility(View.SYSTEM_UI_FLAG_VISIBLE);
 					context.success();
 				}
 				catch (Exception e)

--- a/src/android/com/mesmotronic/plugins/FullScreenPlugin.java
+++ b/src/android/com/mesmotronic/plugins/FullScreenPlugin.java
@@ -29,6 +29,7 @@ public class FullScreenPlugin extends CordovaPlugin
 	public static final String ACTION_SHOW_UNDER_SYSTEM_UI = "showUnderSystemUI";
 	public static final String ACTION_IMMERSIVE_MODE = "immersiveMode";
 	public static final String ACTION_SET_SYSTEM_UI_VISIBILITY = "setSystemUiVisibility";
+	public static final String ACTION_RESET_WINDOW = "resetScreen";
 	
 	private CallbackContext context;
 	private Activity activity;
@@ -96,6 +97,8 @@ public class FullScreenPlugin extends CordovaPlugin
 			return immersiveMode();
 		else if (ACTION_SET_SYSTEM_UI_VISIBILITY.equals(action))
 			return setSystemUiVisibility(args.getInt(0));
+		else if (ACTION_RESET_WINDOW.equals(action))
+			return resetScreen();
 		
 		return false;
 	}
@@ -332,6 +335,32 @@ public class FullScreenPlugin extends CordovaPlugin
 							| View.SYSTEM_UI_FLAG_LAYOUT_HIDE_NAVIGATION;
 					
 					decorView.setSystemUiVisibility(uiOptions);
+					
+					context.success();
+				}
+				catch (Exception e)
+				{
+					context.error(e.getMessage());
+				}
+			}
+		});
+		
+		return true;
+	}
+
+	/**
+	 * Undo the effect of any of the other methods of this plugin
+	 */
+	protected boolean resetScreen()
+	{
+		activity.runOnUiThread(new Runnable()
+		{
+			@Override
+			public void run() 
+			{
+				try
+				{
+					resetWindow();
 					
 					context.success();
 				}

--- a/src/android/com/mesmotronic/plugins/FullScreenPlugin.java
+++ b/src/android/com/mesmotronic/plugins/FullScreenPlugin.java
@@ -360,7 +360,7 @@ public class FullScreenPlugin extends CordovaPlugin
 			{
 				try
 				{
-					resetWindow();
+			        window.clearFlags(WindowManager.LayoutParams.FLAG_TRANSLUCENT_STATUS);
 					
 					context.success();
 				}

--- a/src/android/com/mesmotronic/plugins/FullScreenPlugin.java
+++ b/src/android/com/mesmotronic/plugins/FullScreenPlugin.java
@@ -329,7 +329,7 @@ public class FullScreenPlugin extends CordovaPlugin
 					
 					int uiOptions = 
 						View.SYSTEM_UI_FLAG_LAYOUT_STABLE
-						| View.SYSTEM_UI_FLAG_LAYOUT_FULLSCREEN;
+							| View.SYSTEM_UI_FLAG_LAYOUT_HIDE_NAVIGATION;
 					
 					decorView.setSystemUiVisibility(uiOptions);
 					

--- a/www/AndroidFullScreen.js
+++ b/www/AndroidFullScreen.js
@@ -19,6 +19,11 @@
 		{
 			cordova.exec(successFunction, errorFunction, 'AndroidFullScreen', 'isSupported', []);
 		},
+			
+		resetScreen: function(successFunction, errorFunction)
+		{
+			cordova.exec(successFunction, errorFunction, 'AndroidFullScreen', 'resetScreen', []);
+		},
 
 		isImmersiveModeSupported: function(successFunction, errorFunction)
 		{


### PR DESCRIPTION
Before this change in `showUnderStatusBar` the App wasn't getting under the status bar until the viewport resized through opening the keyboard